### PR TITLE
Implement attendance and swap-fulfillment API routes

### DIFF
--- a/src/app/api/attendance/[id]/route.ts
+++ b/src/app/api/attendance/[id]/route.ts
@@ -1,14 +1,49 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
 import type { Attendance } from '@/types';
 
 type Context = { params: Promise<{ id: string }> };
 
-// TODO: PUT /api/attendance/[id] — update status, notes, or markedBy; 404 if not found
+// PUT /api/attendance/[id] — update status, notes, or markedBy; 404 if not found
 export async function PUT(
   request: NextRequest,
-  context: Context,
+  context: Context
 ): Promise<NextResponse<Attendance | { error: string }>> {
-  void (await context.params);
-  void request;
-  return NextResponse.json({ error: 'Not implemented' }, { status: 501 });
+  try {
+    // unwrap params because Next.js returns a Promise
+    const { id } = await context.params;
+
+    console.log('PUT request received for attendance id:', id);
+
+    // parse JSON body
+    const body = await request.json();
+    const { status, notes, markedBy } = body;
+
+    console.log('Request body:', body);
+    console.log('Updating fields:', { status, notes, markedBy });
+
+    // update attendance record
+    const updatedRecord = await prisma.attendance.update({
+      where: { id },
+      data: { status, notes, markedBy },
+    });
+
+    return NextResponse.json(updatedRecord, { status: 200 });
+  } catch (err: any) {
+    console.error('PUT /api/attendance/[id] error:', err);
+
+    // Prisma error when record not found
+    if (err.code === 'P2025') {
+      return NextResponse.json(
+        { error: 'Attendance record not found' },
+        { status: 404 }
+      );
+    }
+
+    // catch-all for other errors
+    return NextResponse.json(
+      { error: 'Failed to update attendance record' },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/attendance/route.ts
+++ b/src/app/api/attendance/route.ts
@@ -1,15 +1,42 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
 import type { Attendance } from '@/types';
 
-// TODO: GET /api/attendance — return all records ordered by createdAt desc, include user and shift relations
-export async function GET(): Promise<NextResponse<Attendance[]>> {
-  return NextResponse.json([]);
+// GET /api/attendance — return all records ordered by createdAt desc, include user and shift relations
+export async function GET(): Promise<NextResponse<Attendance[] | { error: string }>> {
+  try {
+    const attendanceRecords = await prisma.attendance.findMany({
+      include: {
+        user: true,
+        shift: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(attendanceRecords);
+  } catch (err) {
+    console.error('GET /api/attendance error:', err);
+    return NextResponse.json({ error: 'Failed to fetch attendance records' }, { status: 500 });
+  }
 }
 
-// TODO: POST /api/attendance — create with { userId, shiftId, status?, notes?, markedBy? }
-export async function POST(
-  request: NextRequest,
-): Promise<NextResponse<Attendance | { error: string }>> {
-  void request;
-  return NextResponse.json({ error: 'Not implemented' }, { status: 501 });
+// POST /api/attendance — create record with required fields { userId, shiftId, status } and optional notes, markedBy
+export async function POST(request: NextRequest): Promise<NextResponse<Attendance | { error: string }>> {
+  try {
+    const body = await request.json();
+    const { userId, shiftId, status, notes, markedBy } = body;
+
+    if (!userId || !shiftId || !status) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const newRecord = await prisma.attendance.create({
+      data: { userId, shiftId, status, notes, markedBy },
+    });
+
+    return NextResponse.json(newRecord, { status: 201 });
+  } catch (err) {
+    console.error('POST /api/attendance error:', err);
+    return NextResponse.json({ error: 'Failed to create attendance record' }, { status: 500 });
+  }
 }

--- a/src/app/api/swap-fulfillments/route.ts
+++ b/src/app/api/swap-fulfillments/route.ts
@@ -1,15 +1,45 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
 import type { SwapFulfillment } from '@/types';
 
-// TODO: GET /api/swap-fulfillments — return all fulfillments, include volunteer and swapRequest relations
-export async function GET(): Promise<NextResponse<SwapFulfillment[]>> {
-  return NextResponse.json([]);
+// GET /api/swap-fulfillments — return all records ordered by createdAt desc with related volunteer, swapRequest, and timeBlock
+export async function GET(): Promise<NextResponse<SwapFulfillment[] | { error: string }>> {
+  try {
+    const fulfillments = await prisma.swapFulfillment.findMany({
+      include: {
+        volunteer: true,
+        swapRequest: true,
+        timeBlock: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return NextResponse.json(fulfillments);
+  } catch (err) {
+    console.error('GET /api/swap-fulfillments error:', err);
+    return NextResponse.json({ error: 'Failed to fetch swap fulfillments' }, { status: 500 });
+  }
 }
 
-// TODO: POST /api/swap-fulfillments — create with { swapRequestId, volunteerId, timeBlockId }
+// POST /api/swap-fulfillments — create a new record with required fields swapRequestId, volunteerId, timeBlockId
 export async function POST(
   request: NextRequest,
 ): Promise<NextResponse<SwapFulfillment | { error: string }>> {
-  void request;
-  return NextResponse.json({ error: 'Not implemented' }, { status: 501 });
+  try {
+    const body = await request.json();
+    const { swapRequestId, volunteerId, timeBlockId } = body;
+
+    if (!swapRequestId || !volunteerId || !timeBlockId) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const newFulfillment = await prisma.swapFulfillment.create({
+      data: { swapRequestId, volunteerId, timeBlockId },
+    });
+
+    return NextResponse.json(newFulfillment, { status: 201 });
+  } catch (err) {
+    console.error('POST /api/swap-fulfillments error:', err);
+    return NextResponse.json({ error: 'Failed to create swap fulfillment' }, { status: 500 });
+  }
 }


### PR DESCRIPTION
- Implement GET/POST /api/attendance
- Implement PUT /api/attendance/[id]
- Implement GET/POST /api/swap-fulfillments
In src/app/api/attendance/route.ts, we implemented GET /api/attendance, which returns all users and their fields ordered by createdAt and POST/api/attendance which adds a user to the attendance and returns the user. 

In src/app/api/attendance/[id]/route.ts, we implemented PUT/api/attendance/[id] which tracks the attendance status and notes and returns the user. 

In src/app/api/swap-fulfillments/route.ts we implemented two endpoints:

GET/api/swap-fulfillments— returns all users with their shifts
POST/api/swap-fulfillments — which updates a user's shift and swaps the times 
Both endpoints follow the same patterns as existing routes, using the shared Prisma client singleton.

Link for Postman Tests:
https://nalini2080-541686.postman.co/workspace/Nalini-Agnihotri's-Workspace~2b0b7eb5-1f4d-4782-837a-b3eb07187661/collection/53004641-836de867-a705-4827-a034-ee86dbc5101a?action=share&source=copy-link&creator=53004641

Left in console logs for debugging put. 

Postman tests:
<img width="1440" height="900" alt="Screenshot 2026-03-08 at 3 58 50 PM" src="https://github.com/user-attachments/assets/13fa554a-2317-4504-910e-97f06b1c5cd2" />
<img width="1440" height="900" alt="Screenshot 2026-03-08 at 3 58 59 PM" src="https://github.com/user-attachments/assets/4570f480-6926-44da-9823-4b0aa2f30680" />
<img width="1440" height="900" alt="Screenshot 2026-03-08 at 3 59 02 PM" src="https://github.com/user-attachments/assets/a8d6d91f-9704-4dc5-8ad5-d760bd0cd982" />
<img width="1440" height="900" alt="Screenshot 2026-03-08 at 3 59 11 PM" src="https://github.com/user-attachments/assets/29ed23d5-00be-4a60-865c-3f82667677b3" />
<img width="1440" height="900" alt="Screenshot 2026-03-08 at 3 59 14 PM" src="https://github.com/user-attachments/assets/6d1d15e2-9345-45c6-adf5-8d388c4e39c5" />

Closes #8 

