### PR TITLE
Implemented PUT for SwapRequests

### DIFF
--- a/src/app/api/swap-requests/[id]/route.ts
+++ b/src/app/api/swap-requests/[id]/route.ts
@@ -56,13 +56,13 @@ export async function PUT(
   }
   if (existing.status === "FILLED") {
     return NextResponse.json(
-      { error: "swap request is already filled" },
+      { error: "Swap request is already filled" },
       { status: 400 },
     );
   }
   if (existing.status === "CANCELLED") {
     return NextResponse.json(
-      { error: "swap request is cancelled" },
+      { error: "Swap request is cancelled" },
       { status: 400 },
     );
   }

--- a/src/app/api/swap-requests/[id]/route.ts
+++ b/src/app/api/swap-requests/[id]/route.ts
@@ -1,14 +1,98 @@
-import { NextRequest, NextResponse } from 'next/server';
-import type { SwapRequest } from '@/types';
+import { NextRequest, NextResponse } from "next/server";
+import type { SwapRequest } from "@/types";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
 
 type Context = { params: Promise<{ id: string }> };
+
+function isNotFound(e: unknown): boolean {
+  return (
+    e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025"
+  );
+}
 
 export async function PUT(
   request: NextRequest,
   context: Context,
 ): Promise<NextResponse<SwapRequest | { error: string }>> {
-  void (await context.params);
-  void request;
-  return NextResponse.json({ error: 'Not implemented' }, { status: 501 });
-}
+  const { id } = await context.params;
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Response body must be a valid JSON" },
+      { status: 400 },
+    );
+  }
 
+  const { status, reason } = body as Record<string, unknown>;
+
+  if (typeof status !== "string" || status.trim() === "") {
+    return NextResponse.json(
+      {
+        error: "'status' is required and cannot be empty",
+      },
+      { status: 400 },
+    );
+  }
+
+  if (status !== "OPEN" && status !== "FILLED" && status !== "CANCELLED") {
+    return NextResponse.json(
+      {
+        error: "'status' must be a valid option",
+      },
+      { status: 400 },
+    );
+  }
+
+  const existing = await prisma.swapRequest.findUnique({ where: { id } });
+
+  if (existing === null) {
+    return NextResponse.json(
+      { error: "Swap request not found" },
+      { status: 404 },
+    );
+  }
+  if (existing.status === "FILLED") {
+    return NextResponse.json(
+      { error: "swap request is already filled" },
+      { status: 400 },
+    );
+  }
+  if (existing.status === "CANCELLED") {
+    return NextResponse.json(
+      { error: "swap request is cancelled" },
+      { status: 400 },
+    );
+  }
+
+  if (reason !== undefined && typeof reason !== "string") {
+    return NextResponse.json(
+      { error: "'reason' must be a string" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const updatedRequest = await prisma.swapRequest.update({
+      where: { id },
+      data: {
+        status,
+        reason,
+      },
+    });
+    return NextResponse.json(updatedRequest, { status: 200 });
+  } catch (err: unknown) {
+    if (isNotFound(err)) {
+      return NextResponse.json(
+        { error: "Swap request not found" },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Failed to update swap request" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
### **Summary**
- In `src/app/api/swap-requests/[id]`, we implemented `PUT /api/shifts/[id]`, which updates `status` and `reason`.

### **Testing**
`PUT /api/shifts/[id]` was tested with Postman.
**PUT**
`PUT /api/shifts/a2038943-5505-4a88-8eb5-9dd98387616e` with '{ "status": "FILLED", "reason": "update reason"}' updates the swap request.

Before
<img width="1470" height="235" alt="Screenshot 2026-03-12 at 2 45 43 PM" src="https://github.com/user-attachments/assets/852cf012-a666-46cb-a13e-19fba21d5a30" />

Postman PUT
<img width="951" height="612" alt="Screenshot 2026-03-12 at 2 46 28 PM" src="https://github.com/user-attachments/assets/d19021fa-349a-4140-9cd6-306030100a14" />

After
<img width="1470" height="219" alt="Screenshot 2026-03-12 at 2 46 53 PM" src="https://github.com/user-attachments/assets/9d8c4b27-17ed-4706-bfd4-2648efb4efea" />

**Error Handling**
Invalid Status
<img width="947" height="533" alt="Screenshot 2026-03-12 at 2 53 34 PM" src="https://github.com/user-attachments/assets/2f4058e4-d351-47c7-86b2-93465936daa4" />

Empty Body
<img width="952" height="545" alt="Screenshot 2026-03-12 at 2 53 58 PM" src="https://github.com/user-attachments/assets/8b391faa-4d58-4596-a1d9-f5beedafdeed" />

Non-Existent ID
<img width="948" height="532" alt="Screenshot 2026-03-12 at 2 54 42 PM" src="https://github.com/user-attachments/assets/a65952ea-c7b1-472e-987b-658f962bbe8c" />