### PR TITLE
POST for ShiftAssignments

### DIFF
--- a/src/app/api/shift-assignments/route.ts
+++ b/src/app/api/shift-assignments/route.ts
@@ -28,13 +28,87 @@ export async function GET(): Promise<
   }
 }
 
-// TODO: create a new shift assignment
-// Required fields: userId (string), shiftId (string)
-// Before creating, check that the shift exists and has not exceeded capacity
-// Return 400 if fields are missing, 404 if shift not found, 409 if at capacity, 201 on success
+function isNotFound(e: unknown): boolean {
+  return (
+    e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025'
+  );
+}
+
 export async function POST(
   request: NextRequest,
 ): Promise<NextResponse<ShiftAssignment | { error: string }>> {
-  void request;
-  return NextResponse.json({ error: 'Not implemented' }, { status: 501 });
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'Request body must be valid JSON' },
+      { status: 400 },
+    );
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return NextResponse.json(
+      { error: 'Request body must be an object' },
+      { status: 400 },
+    );
+  }
+
+  const { userId, shiftId } = body as Record<string, unknown>;
+
+  if (typeof userId !== 'string' || userId.trim() === '') {
+    return NextResponse.json(
+      { error: '"userId" is required and cannot be empty' },
+      { status: 400 },
+    );
+  }
+
+  if (typeof shiftId !== 'string' || shiftId.trim() === '') {
+    return NextResponse.json(
+      { error: '"shiftId" is required and cannot be empty' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const shift = await prisma.shift.findUnique({
+      where: { id: shiftId },
+      include: { _count: { select: { assignments: true } } },
+    });
+
+    if (!shift) {
+      return NextResponse.json(
+        { error: `Shift with id "${shiftId}" not found` },
+        { status: 404 },
+      );
+    }
+
+    if (shift._count.assignments >= shift.capacity) {
+      return NextResponse.json(
+        { error: 'Shift is at capacity' },
+        { status: 409 },
+      );
+    }
+
+    const assignment = await prisma.shiftAssignment.create({
+      data: { userId, shiftId },
+      include: {
+        user: true,
+        shift: { include: { timeBlock: true } },
+      },
+    });
+
+    return NextResponse.json(assignment, { status: 201 });
+  } catch (e) {
+    if (isNotFound(e)) {
+      return NextResponse.json(
+        { error: 'Referenced user or shift not found' },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: 'Failed to create shift assignment' },
+      { status: 500 },
+    );
+  }
 }


### PR DESCRIPTION
## Summary

In `src/app/api/shift-assignments/route.ts`, we implemented `POST /api/shift-assignments`, which assigns a volunteer to a shift. It accepts `userId` and `shiftId` in the request body and enforces the shift's capacity limit before creating the assignment.

The route handles the following cases:

- **201** — assignment created successfully, returned with included `user`, `shift`, and `timeBlock` relations
- **400** — `userId` or `shiftId` is missing, empty, not a string, or the body is not valid JSON
- **404** — the shift does not exist (checked via `findUnique`), or the user does not exist (caught via Prisma error code `P2025`)
- **409** — the shift has already reached its capacity, determined by counting existing assignments with `_count`
- **500** — database or unexpected error

The capacity check queries the shift with `include: { _count: { select: { assignments: true } } }` and compares the count against `shift.capacity` before allowing creation. This follows the same patterns as existing routes, using the shared Prisma client singleton from `src/lib/prisma.ts` and the `PrismaClientKnownRequestError` / `P2025` pattern from `src/app/api/time-blocks/[id]/route.ts`.

## Testing
We tested using Postman

- Successfully created
<img width="1430" height="1298" alt="image" src="https://github.com/user-attachments/assets/8ee4db96-8a54-4f11-8aa3-5580ce295d63" />

- Missing `userId`
<img width="1420" height="1192" alt="image" src="https://github.com/user-attachments/assets/35058711-3f1f-47b0-9c9c-69cfbf9cad24" />

- Missing `shiftId`
<img width="1432" height="1090" alt="image" src="https://github.com/user-attachments/assets/abb2ad6c-d201-40ca-a274-74de07cf8e87" />

- Shift at max capacity
<img width="1412" height="1146" alt="image" src="https://github.com/user-attachments/assets/2c918869-b9a8-4a58-9dac-a43220268f23" />

- Invalid `shiftId`
<img width="1422" height="1142" alt="image" src="https://github.com/user-attachments/assets/9227547b-0a1f-4664-a381-d435c4a008db" />
