### PR TITLE
Implemented `useAllShifts` Hook

### DIFF
--- a/src/hooks/useAllShifts.ts
+++ b/src/hooks/useAllShifts.ts
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useState } from "react";
+
+export type Shift = {
+  id: string;
+  date: Date;
+  committee: string;
+  capacity: number;
+  timeBlock: {
+    id: string;
+    name: string;
+    startTime: string;
+    endTime: string;
+  };
+  assignments: Array<{
+    id: string;
+    userId: string;
+    user: {
+      id: string;
+      name: string;
+      email: string;
+    };
+  }>;
+};
+
+type UseAllShiftsReturn = {
+  data: Shift[];
+  isLoading: boolean;
+  error: Error | null;
+};
+
+export function useAllShifts(committee?: string): UseAllShiftsReturn {
+  const [allShifts, setAllShifts] = useState<Shift[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    async function loadAllShifts(): Promise<void> {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch("/api/shifts", {
+          headers: { Accept: "application/json" },
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch shifts");
+        }
+
+        const shifts = (await response.json()) as Shift[];
+        const nextData = shifts.map(
+          (shift): Shift => ({
+            id: shift.id,
+            date: new Date(shift.date),
+            committee: shift.committee,
+            capacity: shift.capacity,
+            timeBlock: {
+              id: shift.timeBlock.id,
+              name: shift.timeBlock.name,
+              startTime: shift.timeBlock.startTime,
+              endTime: shift.timeBlock.endTime,
+            },
+            assignments: shift.assignments.map((assignment) => ({
+              id: assignment.id,
+              userId: assignment.userId,
+              user: {
+                id: assignment.user.id,
+                name: assignment.user.name,
+                email: assignment.user.email,
+              },
+            })),
+          }),
+        );
+
+        if (!isCancelled) {
+          setAllShifts(nextData);
+        }
+      } catch (caughtError: unknown) {
+        if (!isCancelled) {
+          setAllShifts([]);
+          setError(
+            caughtError instanceof Error
+              ? caughtError
+              : new Error("Failed to fetch shifts"),
+          );
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadAllShifts();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  const data = useMemo(() => {
+    return allShifts
+      .filter((shift) => !committee || shift.committee === committee)
+      .sort((a, b) => a.date.getTime() - b.date.getTime());
+  }, [allShifts, committee]);
+
+  return { data, isLoading, error };
+}

--- a/src/hooks/useMyShifts.ts
+++ b/src/hooks/useMyShifts.ts
@@ -74,21 +74,23 @@ export function useMyShifts(
           (await assignmentsResponse.json()) as ShiftAssignmentResponse[];
 
         const nextData = assignments
-          .map((assignment): MyShift => ({
-            assignmentId: assignment.id,
-            shift: {
-              id: assignment.shift.id,
-              date: new Date(assignment.shift.date),
-              committee: assignment.shift.committee,
-              capacity: assignment.shift.capacity,
-            },
-            timeBlock: {
-              id: assignment.shift.timeBlock.id,
-              name: assignment.shift.timeBlock.name,
-              startTime: assignment.shift.timeBlock.startTime,
-              endTime: assignment.shift.timeBlock.endTime,
-            },
-          }))
+          .map(
+            (assignment): MyShift => ({
+              assignmentId: assignment.id,
+              shift: {
+                id: assignment.shift.id,
+                date: new Date(assignment.shift.date),
+                committee: assignment.shift.committee,
+                capacity: assignment.shift.capacity,
+              },
+              timeBlock: {
+                id: assignment.shift.timeBlock.id,
+                name: assignment.shift.timeBlock.name,
+                startTime: assignment.shift.timeBlock.startTime,
+                endTime: assignment.shift.timeBlock.endTime,
+              },
+            }),
+          )
           .sort((a, b) => a.shift.date.getTime() - b.shift.date.getTime());
 
         if (!isCancelled) {


### PR DESCRIPTION
### **Summary**
- Created `src/hooks/useMyShifts.ts` that fetches all shifts in a single call
- Hook optionally accept a committee filter parameter so the hook can be reused for both full admin view and committee-specific views
- Returns `{ data, isLoading, error }` and results are sorted by date ascending

### **Testing**
Created a temporary test component that calls useAllShifts()
<img width="551" height="470" alt="all shifts test" src="https://github.com/user-attachments/assets/3e819ce5-4f54-49c5-bc46-9ac3e884ac00" />
Called useAllShifts("purchasing") to confirm committee filter works
<img width="554" height="459" alt="all shifts purchasing" src="https://github.com/user-attachments/assets/885d47dd-1af3-4bc1-ad37-0167fb4076d4" />